### PR TITLE
fix: rename size field to size_in_mib in createVolume function

### DIFF
--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -183,13 +183,13 @@ func (client *rpcClient) lvStores() ([]LvStore, error) {
 func (client *rpcClient) createVolume(lvolName, lvsName string, sizeMiB int64) (string, error) {
 	params := struct {
 		LvolName      string `json:"lvol_name"`
-		Size          int64  `json:"size"`
+		Size          int64  `json:"size_in_mib"`
 		LvsName       string `json:"lvs_name"`
 		ClearMethod   string `json:"clear_method"`
 		ThinProvision bool   `json:"thin_provision"`
 	}{
 		LvolName:      lvolName,
-		Size:          sizeMiB * 1024 * 1024,
+		Size:          sizeMiB,
 		LvsName:       lvsName,
 		ClearMethod:   cfgLvolClearMethod,
 		ThinProvision: cfgLvolThinProvision,


### PR DESCRIPTION
params in **createVolume** under jsonrpc.go is 
```
		**Size          int64  `json:"size"`**
```

However, this will fail when creating a lvol bdev:
```
192.168.0.203 - - [12/Aug/2025 12:52:44] "POST / HTTP/1.1" 200 -
{"jsonrpc":"2.0","id":2,"method":"bdev_lvol_create","params":{"lvol_name":"pvc-7f7d8ffa-612c-4893-8f00-cc505058913b","size":1073741824,"lvs_name":"lvs","clear_method":"unmap","thin_provision":true}}
{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"spdk_json_decode_object failed"}}\n

```
According to the [SPDK JsonRPC](https://spdk.io/doc/jsonrpc.html) the **bdev_lvol_create** should have **size_in_mib** in its field instead of **size**. So it should be changed to

```
		**Size          int64  `json:"size_in_mib"`**
```